### PR TITLE
Don't double-decode incoming XML

### DIFF
--- a/lib/Net/DAVTalk.pm
+++ b/lib/Net/DAVTalk.pm
@@ -324,9 +324,7 @@ sub Request {
   # }}}
 
   # parse XML response {{{
-  my $Encoded = Encode::decode_utf8($ResponseContent);
-
-  my $Xml = xmlToHash($Encoded);
+  my $Xml = xmlToHash($ResponseContent);
 
   # Normalise XML
 


### PR DESCRIPTION
XML::Fast seems to do that already, and it will happily break
when given wide characters.

This fixes RT#130648.