### PR TITLE
Accept custom headers and use them on request method

### DIFF
--- a/lib/Net/DAVTalk.pm
+++ b/lib/Net/DAVTalk.pm
@@ -266,6 +266,10 @@ sub Request {
     $Headers{'Authorization'} = $Self->auth_header();
   }
 
+  if ($Self->{headers}) {
+      $Headers{$_} = $Self->{headers}->{$_} for ( keys %{ $Self->{headers} } );
+  }
+
   # XXX - Accept-Encoding for gzip, etc?
 
   # }}}


### PR DESCRIPTION
Allow custom headers to be set ie:
`
Net::CardDAVTalk->new(
    headers  => {
        Cookie  => "123",
        Referer => "456"
    }
);
`