### PR TITLE
pass SSL_options down to default ua

### DIFF
--- a/lib/Net/DAVTalk.pm
+++ b/lib/Net/DAVTalk.pm
@@ -86,6 +86,8 @@ Options:
 
     headers: a hashref of additional headers to add to every request
 
+    SSL_options: a hashref of SSL options to pass down to the default
+    user agent
 =cut
 
 # General methods
@@ -141,6 +143,7 @@ sub ua {
   else {
     $Self->{ua} ||= HTTP::Tiny->new(
       agent => "Net-DAVTalk/$VERSION",
+      SSL_options => $Self->{SSL_options},
     );
   }
   return $Self->{ua};

--- a/lib/Net/DAVTalk.pm
+++ b/lib/Net/DAVTalk.pm
@@ -21,11 +21,11 @@ Net::DAVTalk - Interface to talk to DAV servers
 
 =head1 VERSION
 
-Version 0.22
+Version 0.23
 
 =cut
 
-our $VERSION = '0.22';
+our $VERSION = '0.23';
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
HTTP::Tiny since 0.83 defaults to having SSL verification enabled.  Cassandane needs a way to pass along its CA file, otherwise DAV-over-SSL tests fail at the .well-known lookups in Net::DAVTalk->new().

It seems least intrusive to let `new()` accept an SSL_options hashref (defined by IO::Socket::SSL), just like HTTP::Tiny does, and pass it to the HTTP::Tiny constructor.